### PR TITLE
Update ads_1256_stuff.ino

### DIFF
--- a/ads_1256_stuff.ino
+++ b/ads_1256_stuff.ino
@@ -11,12 +11,6 @@
 void initADS() {
   attachInterrupt(ADS_RDY_PIN, DRDY_Interuppt, FALLING);
 
-  digitalWrite(ADS_RST_PIN, LOW);
-  delay(10); // LOW at least 4 clock cycles of onboard clock. 100 microsecons is enough
-  digitalWrite(ADS_RST_PIN, HIGH); // now reset to deafult values
-
-  delay(1000);
-
   //now reset the ADS
   Reset();
 


### PR DESCRIPTION
digitalWriteFast allows you to use constants, so I replaced all 21 with ADS_CS_PIN.

You dont have to use the reset pin, if you send a reset command anyway.

The reset automaticly stops read data continuesly, so dont have to send the SDATAC command.